### PR TITLE
Switch from git-based to date-based tags for dockerhub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,19 @@ TARGET?=binary
 build: clean
 	docker build -t splatform/cf-buildpack-packager .
 
-publish: build
-	docker tag splatform/cf-buildpack-packager splatform/cf-buildpack-packager:$(shell git describe --tags --abbrev=0)
-	docker push splatform/cf-buildpack-packager:$(shell git describe --tags --abbrev=0)
+tagname = $(shell date "+%Y-%m-%d-g`git rev-parse --short HEAD`")
+
+tagname:
+	@echo $(call tagname)
+
+tag: build
+	# Make sure there are no uncommitted changes when tagging the image
+	git diff --no-ext-diff --quiet
+	git diff --no-ext-diff --cached --quiet
+	docker tag splatform/cf-buildpack-packager splatform/cf-buildpack-packager:$(call tagname)
+
+publish: tag
+	docker push splatform/cf-buildpack-packager:$(call tagname)
 	docker push splatform/cf-buildpack-packager
 
 clean:


### PR DESCRIPTION
We want to push an image for every commit to master to docker hub, so can't rely on having a new tag for each merge.

New tags will look like this: `splatform/cf-buildpack-packager:2018-10-30-g22309f7`