### PR TITLE
Add support for go modules based buildpacks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
-FROM opensuse/leap
+ARG base_image=opensuse/leap:15.0
+FROM ${base_image}
 
-RUN zypper in -y go ruby-devel ruby2.5-rubygem-bundler zlib-devel libxml2-devel libxslt-devel gcc make zip which git-core curl jq
+RUN zypper ar https://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Leap_15.0/ go
+RUN zypper --gpg-auto-import-keys -n in go
+
+RUN zypper in -y ruby-devel ruby2.5-rubygem-bundler zlib-devel  \
+                 libxml2-devel libxslt-devel gcc make zip which \
+                 git-core curl jq
 
 ADD package /
 

--- a/package
+++ b/package
@@ -48,6 +48,26 @@ EOF
     done
 fi
 
+function install_buildpack_packager() {
+
+  # Assuming we are in the BUILDPACK directory
+
+  PACKAGER_DIR=$1
+  if [[ -d $PACKAGER_DIR ]]; then
+    (cd ${PACKAGER_DIR} && go install)
+    echo ${PACKAGER_DIR}/main.go
+  elif [[ -e go.mod ]]; then
+    PACKAGER=buildpack-packager.go
+    curl https://raw.githubusercontent.com/cloudfoundry/libbuildpack/master/packager/buildpack-packager/main.go \
+         --silent --output $PACKAGER
+    go install $PACKAGER
+    echo $PACKAGER
+  else
+    (>&2 echo "buildpack-packager missing")
+    exit 1
+  fi
+}
+
 function package() {
     ORG=$1
     LANGUAGE=$2
@@ -95,10 +115,9 @@ function package() {
         bundle
         bundle exec rake clean package OFFLINE=true PINNED=true
         cd build
-    elif [[ -f .envrc && -d ${PACKAGER_DIR} ]]; then
+    elif [[ -f .envrc ]] && [[ -d ${PACKAGER_DIR} || -f go.mod ]]; then
         source .envrc
-        (cd ${PACKAGER_DIR} && go install)
-        MAIN_GO=${PACKAGER_DIR}/main.go
+        MAIN_GO=$(install_buildpack_packager ${PACKAGER_DIR})
         if grep -q github.com/google/subcommands ${MAIN_GO}; then
             if grep -q any-stack ${MAIN_GO}; then
                 if [ -z ${STACK} ]; then


### PR DESCRIPTION
v1.6.34.1 (without go modules):



```
$ docker run -it --rm -v $PWD:/out cf-buildpack-packager:latest SUSE nodejs v1.6.34.1

...

HEAD is now at 4e4686b1 Add SUSE based VERSION and manifest.yml
+ git submodule update --init --recursive
+ '[' -f cf.Gemfile ']'
+ [[ -f Gemfile ]]
+ [[ -f .envrc ]]
+ [[ -d /cf-nodejs-buildpack/src/nodejs/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager ]]                                                                                                
+ source .envrc
++ export GOPATH=/cf-nodejs-buildpack
++ GOPATH=/cf-nodejs-buildpack
++ export GOBIN=/cf-nodejs-buildpack/.bin
++ GOBIN=/cf-nodejs-buildpack/.bin
++ export PATH=/cf-nodejs-buildpack/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++ PATH=/cf-nodejs-buildpack/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++ install_buildpack_packager /cf-nodejs-buildpack/src/nodejs/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager                                                                             
++ PACKAGER_DIR=/cf-nodejs-buildpack/src/nodejs/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager                                                                                           
++ [[ -d /cf-nodejs-buildpack/src/nodejs/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager ]]                                                                                               
++ cd /cf-nodejs-buildpack/src/nodejs/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager                                                                                                     
++ go install
++ echo /cf-nodejs-buildpack/src/nodejs/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager/main.go                                                                                           
+ MAIN_GO=/cf-nodejs-buildpack/src/nodejs/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager/main.go                                                                                         
+ grep -q github.com/google/subcommands /cf-nodejs-buildpack/src/nodejs/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager/main.go                                                           
+ grep -q any-stack /cf-nodejs-buildpack/src/nodejs/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager/main.go                                                                               
+ '[' -z ']'
+ buildpack-packager build --any-stack --cached=true
cached buildpack created and saved as /cf-nodejs-buildpack/nodejs_buildpack-cached-v1.6.34.1.zip with a size of 520MB           
...                                                                                   
```


v1.6.36.1 (with go modules):

```
$ docker run -it --rm -v $PWD:/out cf-buildpack-packager:latest SUSE nodejs v1.6.36.1 

...

+ [[ -f .envrc ]]
+ [[ -d /cf-nodejs-buildpack/src/nodejs/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager ]]                                                                                                
+ [[ -f go.mod ]]
+ source .envrc
+++ pwd
++ export GOBIN=/cf-nodejs-buildpack/.bin
++ GOBIN=/cf-nodejs-buildpack/.bin
++ export PATH=/cf-nodejs-buildpack/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++ PATH=/cf-nodejs-buildpack/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++ install_buildpack_packager /cf-nodejs-buildpack/src/nodejs/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager                                                                             
++ PACKAGER_DIR=/cf-nodejs-buildpack/src/nodejs/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager                                                                                           
++ [[ -d /cf-nodejs-buildpack/src/nodejs/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager ]]                                                                                               
++ [[ -e go.mod ]]
++ PACKAGER=buildpack-packager.go
++ curl https://raw.githubusercontent.com/cloudfoundry/libbuildpack/master/packager/buildpack-packager/main.go --silent --output buildpack-packager.go                                                            
++ go install buildpack-packager.go
go: finding github.com/blang/semver v3.5.1+incompatible
go: finding github.com/golang/mock v1.1.1
go: finding github.com/Masterminds/semver v1.4.2
go: finding github.com/cloudfoundry/libbuildpack v0.0.0-20181128221744-1145c99db82c
go: finding github.com/onsi/gomega v1.4.2
go: finding github.com/tidwall/gjson v1.1.3
go: finding github.com/onsi/ginkgo v1.7.0
go: finding github.com/tidwall/match v0.0.0-20171002075945-1731857f09b1
go: finding gopkg.in/jarcoal/httpmock.v1 v1.0.0-20181025172632-c463961d8bfe
go: finding golang.org/x/sys v0.0.0-20181106135930-3a76605856fd
go: finding github.com/elazarl/goproxy v0.0.0-20181003060214-f58a169a71a5
go: finding github.com/onsi/ginkgo v1.6.0
go: finding github.com/hpcloud/tail v1.0.0
go: finding gopkg.in/fsnotify.v1 v1.4.7
go: finding golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
go: finding golang.org/x/text v0.3.0
go: finding github.com/fsnotify/fsnotify v1.4.7
go: finding golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e
go: finding github.com/golang/protobuf v1.2.0
go: finding gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: finding gopkg.in/yaml.v2 v2.2.1
go: finding golang.org/x/net v0.0.0-20180906233101-161cd47e91fd
go: finding gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
go: downloading github.com/cloudfoundry/libbuildpack v0.0.0-20181128221744-1145c99db82c
go: downloading github.com/blang/semver v3.5.1+incompatible
go: finding github.com/google/subcommands latest
go: downloading github.com/Masterminds/semver v1.4.2
go: downloading gopkg.in/yaml.v2 v2.2.1
go: downloading github.com/google/subcommands v0.0.0-20181012225330-46f0354f6315
++ echo buildpack-packager.go
+ MAIN_GO=buildpack-packager.go
+ grep -q github.com/google/subcommands buildpack-packager.go
+ grep -q any-stack buildpack-packager.go
+ '[' -z ']'
+ buildpack-packager build --any-stack --cached=true
cached buildpack created and saved as /cf-nodejs-buildpack/nodejs_buildpack-cached-v1.6.36.1.zip with a size of 555MB
...                                                                               
```
