### PR TITLE
Get latest Bundler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 ARG base_image=opensuse/leap:15.0
 FROM ${base_image}
 
+RUN zypper in -y ruby-devel zlib-devel libxml2-devel libxslt-devel gcc make \
+                 zip which git-core curl jq
+
+# Get latest go version
 RUN zypper ar https://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Leap_15.0/ go
 RUN zypper --gpg-auto-import-keys -n in go
 
-RUN zypper in -y ruby-devel ruby2.5-rubygem-bundler zlib-devel  \
-                 libxml2-devel libxslt-devel gcc make zip which \
-                 git-core curl jq
+# Get latest ruby gem bundler
+RUN zypper ar https://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/openSUSE_Leap_15.0/ ruby-extensions
+RUN zypper --gpg-auto-import-keys -n in ruby2.5-rubygem-bundler
 
 ADD package /
 

--- a/package
+++ b/package
@@ -100,6 +100,8 @@ function package() {
     git submodule update --init --recursive
 
     if [ -f cf.Gemfile ]; then
+        # Remove bundler lock
+        sed -zEi 's/BUNDLED WITH\s+[0-9.]+//' cf.Gemfile.lock
         BUNDLE_GEMFILE=cf.Gemfile bundle config build.nokogiri --use-system-libraries
         BUNDLE_GEMFILE=cf.Gemfile bundle
         if BUNDLE_GEMFILE=cf.Gemfile bundle exec buildpack-packager --help | grep -q any-stack; then


### PR DESCRIPTION
The latest Java buildpack requires bundler 2.0.1 which is not part
of leap.

We are now running this packager during each buildpack update to verify that it still works.