### PR TITLE
Delete go.sum if it hasn't been touched since 2019-01-01

### DIFF
--- a/package
+++ b/package
@@ -57,6 +57,10 @@ function install_buildpack_packager() {
     (cd ${PACKAGER_DIR} && go install)
     echo ${PACKAGER_DIR}/main.go
   elif [[ -e go.mod ]]; then
+    # go.sum files not modified since 2019 may have been created by Go prior 1.11.4, which had a broken checksum algorithm
+    if [[ -e go.sum && $(git rev-list HEAD --since=2019-01-01 -- go.sum | wc -l) -eq 0 ]]; then
+      rm go.sum
+    fi
     PACKAGER=buildpack-packager.go
     curl https://raw.githubusercontent.com/cloudfoundry/libbuildpack/master/packager/buildpack-packager/main.go \
          --silent --output $PACKAGER


### PR DESCRIPTION
It has likely been generated by an older version of Go (before 1.11.4), and the algorithm to calculate checksums have changed since then.

Without this change I cannot build certain older buildpacks, e.g.

```
$ docker run -it --rm -v /Users/jan/suse/cf-buildpack-packager-docker:/out splatform/cf-buildpack-packager --accept-external-binaries SUSE python v1.6.25
...
go: downloading github.com/cloudfoundry/libbuildpack v0.0.0-20181211154449-49acf76fd9c6
go: verifying github.com/cloudfoundry/libbuildpack@v0.0.0-20181211154449-49acf76fd9c6: checksum mismatch
	downloaded: h1:fG9VCPTdJNeNNwz7eMJAb3JQKsJBwyBsKiucSOqyztc=
	go.sum:     h1:jdQ7/f0GJxM4g0CdMnT2W892FxvyErFuK4yuQY1Ox3A=
```