### PR TITLE
Fix building all buildpacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ publish: tag
 	docker push splatform/cf-buildpack-packager
 
 clean:
-	-rm *.zip 2> /dev/null
+	-rm -f ./*.zip 2> /dev/null
 
 run:
 	docker run -it --rm -v $(PWD):/out splatform/cf-buildpack-packager --accept-external-binaries SUSE $(TARGET)

--- a/package
+++ b/package
@@ -153,6 +153,7 @@ if [ "${org}" == "suse" ]; then
 fi
 
 if [ "${1:-}" == "all" ]; then
+    shift
     for language in binary dotnet-core go java nodejs php python ruby staticfile; do
         # skipping dotnet-core for now because it has no SUSE assets yet
         if [[ "${org}" == "SUSE" && "${language}" == "dotnet-core" ]]; then


### PR DESCRIPTION
We need to remove the "all" name before passing the arguments down
