### PR TITLE
Always get the latest bundler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,7 @@ ARG base_image=opensuse/leap:15.1
 FROM ${base_image}
 
 RUN zypper in -y ruby-devel zlib-devel libxml2-devel libxslt-devel gcc make \
-                 zip which git-core curl jq
-
-# Get latest go version
-RUN zypper ar https://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Leap_15.0/ go
-RUN zypper --gpg-auto-import-keys -n in go
+                 zip which git-core curl jq go
 
 # Get latest ruby gem bundler
 RUN zypper ar https://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/openSUSE_Leap_15.0/ ruby-extensions

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ RUN zypper in -y ruby-devel zlib-devel libxml2-devel libxslt-devel gcc make \
                  zip which git-core curl jq go
 
 # Get latest ruby gem bundler
-RUN zypper ar https://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/openSUSE_Leap_15.0/ ruby-extensions
-RUN zypper --gpg-auto-import-keys -n in ruby2.5-rubygem-bundler
+RUN gem install bundler && ln -s /usr/bin/bundle.ruby* /usr/bin/bundle && ln -s /usr/bin/bundler.ruby* /usr/bin/bundler
 
 ADD package /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_image=opensuse/leap:15.0
+ARG base_image=opensuse/leap:15.1
 FROM ${base_image}
 
 RUN zypper in -y ruby-devel zlib-devel libxml2-devel libxslt-devel gcc make \


### PR DESCRIPTION
A new bundler was used in the Java buildpack but it is not yet available in openSUSE so getting bundler from rubygems.org again and also trigger the docker image pipeline when a new bundler is released (this is done in the pipelines repo).